### PR TITLE
Add web infrastructure for universal links

### DIFF
--- a/website/.well-known/apple-app-site-association
+++ b/website/.well-known/apple-app-site-association
@@ -1,0 +1,17 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "YOUR_TEAM_ID.com.yourcompany.BookAI"
+        ],
+        "components": [
+          {
+            "/": "/*",
+            "comment": "Matches any shared link"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/website/_redirects
+++ b/website/_redirects
@@ -1,0 +1,3 @@
+/ /index.html 200
+/shared/* /shared/index.html 200
+/.well-known/apple-app-site-association /.well-known/apple-app-site-association 200

--- a/website/deploy-guide.md
+++ b/website/deploy-guide.md
@@ -1,0 +1,20 @@
+# Deploying bookaiapp.com
+
+This folder contains a minimal static website for hosting Universal Links.
+You can deploy it with Netlify, Vercel or GitHub Pages.
+
+## Netlify
+1. Create a new site from this repository.
+2. Netlify will automatically detect the `_redirects` file.
+3. Configure the domain `bookaiapp.com` in the site settings.
+
+## Vercel
+1. Import the repository on [Vercel](https://vercel.com).
+2. Vercel will read `vercel.json` for routing rules.
+3. Assign `bookaiapp.com` to the project.
+
+## GitHub Pages
+1. Enable Pages in repository settings.
+2. Set the branch to deploy from and configure DNS for `bookaiapp.com`.
+
+After deploying, ensure `https://bookaiapp.com/.well-known/apple-app-site-association` returns this folder's AASA file without redirects.

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BookAI App</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      background: linear-gradient(120deg, #84fab0 0%, #8fd3f4 100%);
+      display: flex;
+      height: 100vh;
+      justify-content: center;
+      align-items: center;
+      color: #333;
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      padding: 40px;
+      text-align: center;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+    }
+    h1 {
+      margin-bottom: 10px;
+    }
+    p {
+      margin-bottom: 30px;
+    }
+    a {
+      background: #4a90e2;
+      color: #fff;
+      text-decoration: none;
+      padding: 12px 24px;
+      border-radius: 24px;
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Welcome to BookAI</h1>
+    <p>Create and share AI‑generated books with ease.</p>
+    <a href="https://github.com/AppDevMasters/bookaiapp" target="_blank">Learn More</a>
+  </div>
+</body>
+</html>

--- a/website/setup-website.md
+++ b/website/setup-website.md
@@ -1,0 +1,7 @@
+# Quick Setup Checklist
+
+- [ ] Domain `bookaiapp.com` configured
+- [ ] Website deployed (Netlify, Vercel or GitHub Pages)
+- [ ] AASA file updated with real Team ID and Bundle ID
+- [ ] Test `https://bookaiapp.com/shared/test` opens the app
+- [ ] Test AASA file accessible at `/.well-known/apple-app-site-association`

--- a/website/shared/index.html
+++ b/website/shared/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BookAI Shared Book</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+      margin: 0;
+      padding: 40px 20px;
+      text-align: center;
+    }
+    .card {
+      max-width: 500px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      padding: 30px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    }
+    a.button {
+      display: inline-block;
+      margin-top: 20px;
+      background: #4a90e2;
+      color: #fff;
+      padding: 12px 24px;
+      border-radius: 24px;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Open in BookAI</h1>
+    <p>If the app doesn't open automatically, tap below to download.</p>
+    <a href="#" class="button" id="download">Get the App</a>
+  </div>
+  <script>
+    const path = window.location.pathname.split('/');
+    const id = path[path.indexOf('shared') + 1];
+    if(id) {
+      setTimeout(() => {
+        window.location.href = `bookaiapp://shared/${id}`;
+      }, 500);
+    }
+  </script>
+</body>
+</html>

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,6 @@
+{
+  "rewrites": [
+    { "source": "/shared/:book", "destination": "/shared/index.html" },
+    { "source": "/", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `website` directory with landing page and shared page
- provide apple-app-site-association and routing files
- document how to deploy the site

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68416afaefe48324a0ca7a703fc4c006